### PR TITLE
Use upstream constraints for Jinja2 and Markupsafe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: cf5104777571b2b7f06fa88ee08fade24563f4a0594cf4bd17d31c47b8740b4c
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -29,7 +29,8 @@ requirements:
     - babel >=1.3
     - docutils >=0.14,<0.18
     - imagesize
-    - jinja2 >=2.3
+    - jinja2 >=2.3,<3.0
+    - markupsafe <2.0
     - packaging
     - pygments >=2.0
     - python


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/blob/bde181674d8a136358ff0a1ca991006bf23f489c/setup.py#L24-L25. Currently, if you `pip install -e .` in a project that depends on `sphinx`, `pip` overwrites the conda packages of Jinja2 and MarkupSafe. I see support for Jinja2 3.0 has been merged in sphinx but I don't know when a release with that fix will be published.